### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -45,13 +45,13 @@ htu21_status_i2c_transfer_error	LITERAL1
 htu21_status_no_i2c_acknowledge	LITERAL1
 htu21_status_crc_error	LITERAL1
 
-htu21_heater_off	LITERAL1	
-htu21_heater_on		LITERAL1
+htu21_heater_off	LITERAL1
+htu21_heater_on	LITERAL1
 
 htu21_battery_ok	LITERAL1
 htu21_battery_low	LITERAL1
 
-htu21_resolution_t_14b_rh_12b 	LITERAL1
+htu21_resolution_t_14b_rh_12b	LITERAL1
 htu21_resolution_t_12b_rh_8b	LITERAL1
 htu21_resolution_t_13b_rh_10b	LITERAL1
 htu21_resolution_t_11b_rh_11b	LITERAL1


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords